### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/mentaljam/rollup-plugin-zip",
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/mentaljam/rollup-plugin-zip"
+    "url": "git+https://github.com/mentaljam/rollup-plugin-zip.git"
   },
   "bugs": {
     "url": "https://github.com/mentaljam/rollup-plugin-zip/issues"


### PR DESCRIPTION
## Summary
- Replace the published package repository URL with a public HTTPS Git URL.

## Verification
- Confirmed the compare diff only changes the repository URL in package.json.
